### PR TITLE
Add NetBSD install

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ Install with cargo:
 cargo install saturn-cli
 ```
 
+On NetBSD a pre-compiled package is available from the official repositories. To install it, simply run:
+
+```
+pkgin install saturn-cli
+```
+
 ## Entry language
 
 Entry language is basically:


### PR DESCRIPTION
`saturn-cli` now available on NetBSD. Merge log for your reference, http://mail-index.netbsd.org/pkgsrc-changes/2023/10/02/msg283126.html

Please consider adding the install instructions to README.md, thanks!